### PR TITLE
[fix][broker]consumer backlog eviction policy should not reset read position for consumer

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -218,8 +218,8 @@ public class BacklogQuotaManager {
                     ManagedCursor slowestConsumer = mLedger.getSlowestConsumer();
                     Position oldestPosition = slowestConsumer.getMarkDeletedPosition();
                     Position oldestReadPosition = slowestConsumer.getReadPosition();
-                    if(log.isInfoEnabled()) {
-                        log.info("[{}] slowest consumer mark delete position is [{}], read position is [{}]",
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}] slowest consumer mark delete position is [{}], read position is [{}]",
                                 slowestConsumer.getName(), oldestPosition.toString(), oldestReadPosition.toString());
                     }
                     ManagedLedgerInfo.LedgerInfo ledgerInfo = mLedger.getLedgerInfo(oldestPosition.getLedgerId()).get();
@@ -229,8 +229,8 @@ public class BacklogQuotaManager {
                         slowestConsumer.asyncMarkDelete(nextPosition, new AsyncCallbacks.MarkDeleteCallback() {
                             @Override
                             public void markDeleteComplete(Object ctx) {
-                                if (log.isInfoEnabled()) {
-                                    log.info("[{}] subscription mark deleted messages at position [{}]",
+                                if (log.isDebugEnabled()) {
+                                    log.debug("[{}] subscription mark deleted messages at position [{}]",
                                             slowestConsumer.getName(), nextPosition);
                                 }
                                 countDownLatch.countDown();
@@ -258,8 +258,8 @@ public class BacklogQuotaManager {
                             slowestConsumer.asyncMarkDelete(nextPosition, new AsyncCallbacks.MarkDeleteCallback() {
                                 @Override
                                 public void markDeleteComplete(Object ctx) {
-                                    if (log.isInfoEnabled()) {
-                                        log.info("[{}] subscription mark deleted messages at position [{}]",
+                                    if (log.isDebugEnabled()) {
+                                        log.debug("[{}] subscription mark deleted messages at position [{}]",
                                                 slowestConsumer.getName(), nextPosition);
                                     }
                                     countDownLatch.countDown();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -215,8 +215,7 @@ public class BacklogQuotaManager {
                     Position oldestPosition = slowestConsumer.getMarkDeletedPosition();
                     if (log.isDebugEnabled()) {
                         log.debug("[{}] slowest consumer mark delete position is [{}], read position is [{}]",
-                                slowestConsumer.getName(), oldestPosition.toString(),
-                                slowestConsumer.getReadPosition().toString());
+                                slowestConsumer.getName(), oldestPosition, slowestConsumer.getReadPosition());
                     }
                     ManagedLedgerInfo.LedgerInfo ledgerInfo = mLedger.getLedgerInfo(oldestPosition.getLedgerId()).get();
                     if (ledgerInfo == null) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
@@ -37,7 +37,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
-import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.Cleanup;
+import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.PulsarService;
@@ -515,7 +516,7 @@ public class BacklogQuotaManagerTest {
 
         PersistentTopic topic1Reference = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topic1).get();
         ManagedLedgerImpl ml = (ManagedLedgerImpl) topic1Reference.getManagedLedger();
-        assertEquals(ml.getSlowestConsumer().getReadPosition(), PositionImpl.get(2,4));
+        Position slowConsumerReadPos = ml.getSlowestConsumer().getReadPosition();
 
         Thread.sleep((TIME_TO_CHECK_BACKLOG_QUOTA * 2) * 1000);
         rolloverStats();
@@ -528,7 +529,7 @@ public class BacklogQuotaManagerTest {
             assertEquals(stats2.getSubscriptions().get(subName2).getMsgBacklog(), ml.getCurrentLedgerEntries());
         });
 
-        assertEquals(ml.getSlowestConsumer().getReadPosition(), PositionImpl.get(2,4));
+        assertEquals(ml.getSlowestConsumer().getReadPosition(), slowConsumerReadPos);
         client.close();
     }
 


### PR DESCRIPTION
### Motivation
fix #18036


### Modifications
- The backlog eviction policy should use `asyncMarkDelete` instead of `resetCursor` in order to move the mark delete position.

### Verifying this change

- [x]  Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.
### Does this pull request potentially affect one of the following parts:

If `yes` was chosen, please highlight the changes

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The schema: (no)
- The default values of configurations: (no)
- The wire protocol: (no)
- The rest endpoints: (no)
- The admin cli options: (no)
- Anything that affects deployment: (no)

### Documentation

Check the box below or label this PR directly.

Need to update docs?

- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc` 
- [ ] `doc-complete`

### Matching PR in forked repository

PR in forked repository: https://github.com/HQebupt/pulsar/pull/5